### PR TITLE
**Objective**: Refactor milestone identifier naming to improve semant…

### DIFF
--- a/src/formatter/repository.rs
+++ b/src/formatter/repository.rs
@@ -79,8 +79,8 @@ pub fn repository_body_markdown_with_timezone(
                 String::new()
             };
             content.push_str(&format!(
-                "- {} (Milestone ID: {}){}\n",
-                milestone.milestone_name, milestone.milestone_id, due_date_info
+                "- {} (Milestone number: #{}){}\n",
+                milestone.milestone_name, milestone.milestone_number.0, due_date_info
             ));
         }
 

--- a/src/types/repository.rs
+++ b/src/types/repository.rs
@@ -162,9 +162,9 @@ impl From<&str> for RepositoryUrl {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MilestoneId(pub u64);
+pub struct MilestoneNumber(pub u64);
 
-impl std::fmt::Display for MilestoneId {
+impl std::fmt::Display for MilestoneNumber {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -185,8 +185,7 @@ impl std::fmt::Display for MilestoneName {
 /// storing both the numeric milestone ID and the human-readable milestone name.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RepositoryMilestone {
-    /// The numeric milestone identifier as assigned by GitHub
-    pub milestone_id: MilestoneId,
+    pub milestone_number: MilestoneNumber,
     /// The human-readable milestone name as displayed in GitHub
     pub milestone_name: MilestoneName,
 
@@ -426,7 +425,7 @@ impl TryFrom<RepositoryNode> for GithubRepository {
                     .map(|date| date.with_timezone(&Utc));
 
                 RepositoryMilestone {
-                    milestone_id: MilestoneId(milestone.number),
+                    milestone_number: MilestoneNumber(milestone.number as u64),
                     milestone_name: MilestoneName(milestone.title),
                     due_date,
                 }


### PR DESCRIPTION
…ic clarity and align with GitHub API terminology, changing from generic "milestone_id" to more descriptive "milestone_number" to better reflect the actual meaning of the field.

**Primary Changes**: Renamed MilestoneId to MilestoneNumber and updated all references throughout the codebase, including struct fields, display formatting, and GraphQL response parsing.

**Key Technical Concepts**: Rust struct refactoring, type alias renaming, GraphQL response mapping, and display formatting consistency.

**Files and Code Sections**:
- src/types/repository.rs: Renamed MilestoneId to MilestoneNumber struct and updated RepositoryMilestone.milestone_id field to milestone_number
- src/formatter/repository.rs: Updated milestone display format from "Milestone ID" to "Milestone number" with # prefix for better GitHub consistency

**Problem Solving**: Addresses semantic confusion between GitHub's milestone "number" field (which is actually a sequential identifier) and the generic term "ID", improving code readability and API alignment.

**Impact**: Enhances code clarity and maintains consistency with GitHub's terminology while preserving all existing functionality.

**Related Commits**: Related to previous refactoring efforts in the repository types module.

**Unresolved TODOs**: None